### PR TITLE
Update to esamattis/npm-release

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -7,7 +7,7 @@ jobs:
         steps:
             - uses: actions/checkout@v1
             - name: Make prerelease to npm
-              uses: epeli/npm-release@v1
+              uses: esamattis/npm-release@v1
               with:
                   type: prerelease
                   token: ${{ secrets.CAZOO_NPM_TOKEN }}


### PR DESCRIPTION
https://github.com/epeli/npm-release redirects to https://github.com/esamattis/npm-release so this PR uses that instead.