### PR TITLE
Add no-restricted-global rule for location

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cazoo/eslint-plugin-eslint",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cazoo/eslint-plugin-eslint",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "ESLint rules for Cazoo org",
   "main": "src/index.js",
   "author": "Adrien Baron <adrien.baron@cazoo.co.uk>",

--- a/src/index.js
+++ b/src/index.js
@@ -78,6 +78,7 @@ module.exports = {
       },
       "rules": {
         ...baseConfig.rules,
+        "no-restricted-globals": ["location"],
         "react/prop-types": "off",
       },
       "plugins": ["react", ...baseConfig.plugins],


### PR DESCRIPTION
## Why

1. We got stung by accidentally using the global `location`
    See the post-mortem: [**📍Corrupt Location Data**](https://www.notion.so/teamcazoo/Corrupt-Location-Data-aa11bbc80ab94c9e99dc6bae6fbaee07)

## What

- [x] Avoid accidental use of the global `location` object

## Notes

1. Here is the rule in action [via a very contrived example]
    <img width="868" alt="Screenshot 2022-03-18 at 17 19 02" src="https://user-images.githubusercontent.com/353044/159053392-5e253d96-0938-4320-9fe3-4bc340efcca7.png">
1. This doesn't stop us using `window.location` if we explicity want to
3. I had a look at [`no-implicit-globals`](https://eslint.org/docs/rules/no-implicit-globals#no-implicit-globals) but found that [`no-restricted-globals`](https://eslint.org/docs/rules/no-restricted-globals) was what was needed
4. This could be added directly to https://github.com/Cazoo-uk/vehicle-lifecycle but I think it's better to share it everywhere
 